### PR TITLE
Icon fixes for XFCE and MATE

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,7 @@ class Application(Adw.Application):
         self.version = version
 
         GLib.set_application_name("Mousai")
+        GLib.set_prgname('io.github.seadve.Mousai')
 
     def do_startup(self):
         Adw.Application.do_startup(self)

--- a/src/widgets/main_window.py
+++ b/src/widgets/main_window.py
@@ -24,6 +24,8 @@ class MainWindow(Adw.ApplicationWindow):
         super().__init__(**kwargs)
         self.settings = settings
 
+        self.set_default_icon_name('io.github.seadve.Mousai')
+
         self.history_model = Gio.ListStore.new(Song)
         self.history_listbox.bind_model(self.history_model, self.new_song_row)
 


### PR DESCRIPTION
1. Fixed icon in XFCE docklike plugin

Before

![beforemousai](https://user-images.githubusercontent.com/3063132/130571680-7152b7fe-46ed-4300-85fd-8f90316572ea.png)

After

![aftermousai](https://user-images.githubusercontent.com/3063132/130571687-b3e3f87c-2299-4187-b63e-82fe1052846c.png)

2. Fixed missing icon in window previews in XFCE and MATE (similar to https://github.com/rafaelmardojai/blanket/issues/54)

Before

![beforemousai2](https://user-images.githubusercontent.com/3063132/130571838-a414bdff-ceb2-41d0-a2ed-554e846e8fba.png)

After

![image](https://user-images.githubusercontent.com/3063132/130571928-b9207827-2284-4078-bf78-d224e72e4f93.png)