### PR TITLE
Update GNOME Platform to master

### DIFF
--- a/io.github.seadve.Mousai.json
+++ b/io.github.seadve.Mousai.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.seadve.Mousai",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "40",
+    "runtime-version" : "master",
     "sdk" : "org.gnome.Sdk",
     "command" : "mousai",
     "finish-args" : [


### PR DESCRIPTION
I built it from source & it works with platform version master. Feel free to close this PR if Mousai doesn't work well with GNOME Platform master.
## Benefits of moving
- No updating the platform version every release