### PR TITLE
general: Improve headerbar tooltips

### DIFF
--- a/data/resources/ui/history-view.ui
+++ b/data/resources/ui/history-view.ui
@@ -62,7 +62,7 @@
                     </child>
                     <child type="end">
                       <object class="GtkMenuButton">
-                        <property name="tooltip-text" translatable="yes">Open Main Menu</property>
+                        <property name="tooltip-text" translatable="yes">Main Menu</property>
                         <property name="icon-name">open-menu-symbolic</property>
                         <property name="menu-model">menu</property>
                         <property name="primary">True</property>

--- a/data/resources/ui/recognized-page.ui
+++ b/data/resources/ui/recognized-page.ui
@@ -19,7 +19,7 @@
         </style>
         <child>
           <object class="GtkButton">
-            <property name="tooltip-text" translatable="yes">Go Back</property>
+            <property name="tooltip-text" translatable="yes">Back</property>
             <property name="icon-name">go-previous-symbolic</property>
             <property name="action-name">win.navigate-back</property>
           </object>

--- a/data/resources/ui/song-page.ui
+++ b/data/resources/ui/song-page.ui
@@ -27,7 +27,7 @@
         </property>
         <child>
           <object class="GtkButton">
-            <property name="tooltip-text" translatable="yes">Go Back</property>
+            <property name="tooltip-text" translatable="yes">Back</property>
             <property name="icon-name">go-previous-symbolic</property>
             <property name="action-name">win.navigate-back</property>
           </object>


### PR DESCRIPTION
The HIG recommends the use of "Main Menu" for primary menu's tooltip and "Back" for back buttons.