### PR TITLE
CI: Remove rust action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
       - name: Create blank versions of configured file
         run: echo -e "" >> src/config.rs
       - name: Run cargo fmt


### PR DESCRIPTION
## Changes

- Remove `action-rs/toolchain`

## Details

As mentioned in #74, `cargo` and other rust tools are present by default in [Ubuntu GitHub runners](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#rust-tools) so the unmaintained action is no longer required.

## Testing

The change has been tested in my fork and the action run can be found [here](https://github.com/kbdharun/Mousai/actions/runs/4935899142)