### PR TITLE
data: Mark release descriptions as untranslatable

### DIFF
--- a/data/io.github.seadve.Mousai.metainfo.xml.in.in
+++ b/data/io.github.seadve.Mousai.metainfo.xml.in.in
@@ -40,7 +40,7 @@
   <content_rating type="oars-1.0"/>
   <releases>
     <release version="0.7.5" date="2023-05-02">
-      <description>
+      <description translatable="no">
         <p>This release contains the following changes:</p>
         <ul>
           <li>Added suggestions and more helpful messages when a recording is saved</li>
@@ -53,7 +53,7 @@
       </description>
     </release>
     <release version="0.7.4" date="2023-04-26">
-      <description>
+      <description translatable="no">
         <p>This release contains new features and fixes:</p>
         <ul>
           <li>Added blur background on song player bar</li>
@@ -62,7 +62,7 @@
       </description>
     </release>
     <release version="0.7.3" date="2023-04-22">
-      <description>
+      <description translatable="no">
         <p>This release contains a new feature and translation updates:</p>
         <ul>
           <li>Save the recording when the error is non-permanent even in non-offline mode</li>
@@ -72,7 +72,7 @@
       </description>
     </release>
     <release version="0.7.2" date="2023-04-12">
-      <description>
+      <description translatable="no">
         <p>This release contains fixes:</p>
         <ul>
           <li>Added tooltip text on select tile button</li>
@@ -82,7 +82,7 @@
       </description>
     </release>
     <release version="0.7.1" date="2023-04-09">
-      <description>
+      <description translatable="no">
         <p>This release contains new features and fixes:</p>
         <ul>
           <li>Added button to try again on no matches</li>
@@ -96,7 +96,7 @@
       </description>
     </release>
     <release version="0.7.0" date="2023-04-06">
-      <description>
+      <description translatable="no">
         <p>This update contains huge UI updates and fixes:</p>
         <ul>
           <li>New feature-rich UI</li>
@@ -114,7 +114,7 @@
       </description>
     </release>
     <release version="0.6.6" date="2021-09-08">
-      <description>
+      <description translatable="no">
         <p>This update contains a fix and translation updates:</p>
         <ul>
           <li>Fixed wrong audio source</li>
@@ -123,7 +123,7 @@
       </description>
     </release>
     <release version="0.6.5" date="2021-09-08">
-      <description>
+      <description translatable="no">
         <p>This is a very minor release containing translations update:</p>
         <ul>
           <li>Updated Chinese (Simplified) translations</li>
@@ -132,7 +132,7 @@
       </description>
     </release>
     <release version="0.6.4" date="2021-09-02">
-      <description>
+      <description translatable="no">
         <p>This update contains new translations:</p>
         <ul>
           <li>Updated Turkish translations</li>
@@ -142,7 +142,7 @@
       </description>
     </release>
     <release version="0.6.3" date="2021-08-27">
-      <description>
+      <description translatable="no">
         <p>This is a minor release containing updated translations:</p>
         <ul>
           <li>Updated Finnish translations</li>
@@ -151,7 +151,7 @@
       </description>
     </release>
     <release version="0.6.2" date="2021-08-25">
-      <description>
+      <description translatable="no">
         <p>This is a fix release:</p>
         <ul>
           <li>Fix missing temporary directory</li>
@@ -159,7 +159,7 @@
       </description>
     </release>
     <release version="0.6.1" date="2021-08-24">
-      <description>
+      <description translatable="no">
         <p>This release contains bug fixes and translations updates:</p>
         <ul>
           <li>Fixed missiong icon on XFCE (thanks to @apandada1)</li>
@@ -170,7 +170,7 @@
       </description>
     </release>
     <release version="0.6.0" date="2021-08-22">
-      <description>
+      <description translatable="no">
         <p>This release contains UI and translation improvements:</p>
         <ul>
           <li>Improved playing animation</li>
@@ -185,7 +185,7 @@
       </description>
     </release>
     <release version="0.5.2" date="2021-08-10">
-      <description>
+      <description translatable="no">
         <p>This is a small update with miscellaneous improvements:</p>
         <ul>
           <li>Added a beep sound when trying to do something</li>
@@ -199,7 +199,7 @@
       </description>
     </release>
     <release version="0.5.1" date="2021-08-08">
-      <description>
+      <description translatable="no">
         <p>This is a small update with miscellaneous improvements:</p>
         <ul>
           <li>More fine-tuned user interface</li>
@@ -209,7 +209,7 @@
       </description>
     </release>
     <release version="0.5.0" date="2021-08-06">
-      <description>
+      <description translatable="no">
         <p>A semi-big release containing new features and major bug fixes:</p>
         <ul>
           <li>Added the ability to select preferred audio source (Either microphone or from desktop audio)</li>
@@ -225,7 +225,7 @@
       </description>
     </release>
     <release version="0.4.4" date="2021-08-03">
-      <description>
+      <description translatable="no">
         <p>This update contains translations and minor ui fixes:</p>
         <ul>
           <li>Minor user interface improvements</li>
@@ -235,7 +235,7 @@
       </description>
     </release>
     <release version="0.4.3" date="2021-07-28">
-      <description>
+      <description translatable="no">
         <p>This update contains translations and minor fixes:</p>
         <ul>
           <li>Better user experience with token dialog</li>
@@ -249,7 +249,7 @@
       </description>
     </release>
     <release version="0.4.2" date="2021-07-03">
-      <description>
+      <description translatable="no">
         <p>This update contains minor fixes:</p>
         <ul>
           <li>Added option to not show token dialog at startup</li>
@@ -259,7 +259,7 @@
       </description>
     </release>
     <release version="0.4.1" date="2021-05-23">
-      <description>
+      <description translatable="no">
         <p>This contains some fixes for the last update:</p>
         <ul>
           <li>Improved UI icons</li>
@@ -270,7 +270,7 @@
       </description>
     </release>
     <release version="0.4.0" date="2021-05-22">
-      <description>
+      <description translatable="no">
         <p>A release containing exciting new features and fixes!</p>
         <ul>
           <li>New built-in player for the identified music</li>
@@ -291,7 +291,7 @@
       </description>
     </release>
     <release version="0.3.2" date="2021-05-05">
-      <description>
+      <description translatable="no">
         <p>Not a big release, but it has some notable changes:</p>
         <ul>
           <li>Improved UI experience</li>
@@ -312,7 +312,7 @@
       </description>
     </release>
     <release version="0.3.1" date="2021-04-09">
-      <description>
+      <description translatable="no">
         <p>Minor improvements:</p>
         <ul>
           <li>Minor UI Improvements</li>
@@ -322,7 +322,7 @@
       </description>
     </release>
     <release version="0.3.0" date="2021-04-08">
-      <description>
+      <description translatable="no">
         <p>New features and performance improvements:</p>
         <ul>
           <li>Added a play button to preview songs</li>
@@ -334,7 +334,7 @@
       </description>
     </release>
     <release version="0.2.0" date="2021-03-31">
-      <description>
+      <description translatable="no">
         <p>This update brings few bug fixes:</p>
         <ul>
           <li>Fixed a bug when there are two similar named songs</li>
@@ -347,7 +347,7 @@
       </description>
     </release>
     <release version="0.1.0" date="2021-03-30">
-      <description>
+      <description translatable="no">
         <p>Initial release.</p>
       </description>
     </release>


### PR DESCRIPTION
GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.