### PR TITLE
appdata: add vcs-browser and translate support

### DIFF
--- a/data/io.github.seadve.Mousai.metainfo.xml.in.in
+++ b/data/io.github.seadve.Mousai.metainfo.xml.in.in
@@ -36,6 +36,7 @@
   <url type="homepage">https://github.com/SeaDve/Mousai</url>
   <url type="bugtracker">https://github.com/SeaDve/Mousai/issues</url>
   <url type="translate">https://hosted.weblate.org/projects/kooha/mousai</url>
+  <url type="vcs-browser">https://github.com/SeaDve/Mousai</url>
   <url type="donation">https://www.buymeacoffee.com/seadve</url>
   <content_rating type="oars-1.0"/>
   <releases>


### PR DESCRIPTION
These urls are visible on Flathub and GNOME Control Center.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url