### PR TITLE
Appdata related patches

### DIFF
--- a/data/io.github.seadve.Mousai.metainfo.xml.in.in
+++ b/data/io.github.seadve.Mousai.metainfo.xml.in.in
@@ -36,6 +36,7 @@
   <url type="homepage">https://github.com/SeaDve/Mousai</url>
   <url type="bugtracker">https://github.com/SeaDve/Mousai/issues</url>
   <url type="translate">https://hosted.weblate.org/projects/kooha/mousai</url>
+  <url type="vcs-browser">https://github.com/SeaDve/Mousai</url>
   <url type="donation">https://www.buymeacoffee.com/seadve</url>
   <content_rating type="oars-1.0"/>
   <releases>
@@ -369,7 +370,6 @@
     <control>touch</control>
   </recommends>
   <custom>
-    <value key="Purism::form_factor">workstation</value>
     <value key="Purism::form_factor">mobile</value>
   </custom>
 </component>

--- a/data/meson.build
+++ b/data/meson.build
@@ -43,11 +43,11 @@ appdata_file = i18n.merge_file(
   install_dir: datadir / 'metainfo'
 )
 # Validate Appdata
-if appstream_util.found()
+if appstreamcli.found()
   test(
-    'validate-appdata', appstream_util,
+    'validate-appdata', appstreamcli,
     args: [
-      'validate', '--nonet', appdata_file.full_path()
+      'validate', '--no-net', appdata_file.full_path()
     ],
     depends: appdata_file,
   )

--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,7 @@ dependency('libpulse', version: '>= 16.0')
 glib_compile_resources = find_program('glib-compile-resources', required: true)
 glib_compile_schemas = find_program('glib-compile-schemas', required: true)
 desktop_file_validate = find_program('desktop-file-validate', required: false)
-appstream_util = find_program('appstream-util', required: false)
+appstreamcli = find_program('appstreamcli', required: false)
 cargo = find_program('cargo', required: true)
 
 version = meson.project_version()


### PR DESCRIPTION
### appdata: Use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.

appdata: Update appdata

- Add cvs-browser URL
- Remove dubplicated Purism tag to pass validation test.

This URL is visible on Flathub and GNOME Software.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url