### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/data/io.github.seadve.Mousai.metainfo.xml.in.in
+++ b/data/io.github.seadve.Mousai.metainfo.xml.in.in
@@ -35,6 +35,7 @@
   </screenshots>
   <url type="homepage">https://github.com/SeaDve/Mousai</url>
   <url type="bugtracker">https://github.com/SeaDve/Mousai/issues</url>
+  <url type="vcs-browser">https://github.com/SeaDve/Mousai</url>
   <url type="translate">https://hosted.weblate.org/projects/kooha/mousai</url>
   <url type="donation">https://www.buymeacoffee.com/seadve</url>
   <content_rating type="oars-1.0"/>
@@ -371,7 +372,11 @@
     <kudo>ModernToolkit</kudo>
     <kudo>HiDpiIcon</kudo>
   </kudos>
-  <developer_name>Dave Patrick Caberto</developer_name>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
+  <developer_name translatable="no">Dave Patrick Caberto</developer_name>
+  <developer id="gitlab.com">
+      <name translatable="no">Dave Patrick Caberto</name>
+  </developer>
   <update_contact>davecruz48@gmail.com</update_contact>
   <translation type="gettext">@gettext-package@</translation>
   <launchable type="desktop-id">@app-id@.desktop</launchable>
@@ -384,7 +389,6 @@
     <control>touch</control>
   </recommends>
   <custom>
-    <value key="Purism::form_factor">workstation</value>
     <value key="Purism::form_factor">mobile</value>
   </custom>
 </component>

--- a/data/meson.build
+++ b/data/meson.build
@@ -43,11 +43,11 @@ appdata_file = i18n.merge_file(
   install_dir: datadir / 'metainfo'
 )
 # Validate Appdata
-if appstream_util.found()
+if appstreamcli.found()
   test(
-    'validate-appdata', appstream_util,
+    'validate-appdata', appstreamcli,
     args: [
-      'validate', '--nonet', appdata_file.full_path()
+      'validate', '--no-net', '--explain', appdata_file.full_path()
     ],
     depends: appdata_file,
   )

--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,7 @@ dependency('libpulse', version: '>= 16.0')
 glib_compile_resources = find_program('glib-compile-resources', required: true)
 glib_compile_schemas = find_program('glib-compile-schemas', required: true)
 desktop_file_validate = find_program('desktop-file-validate', required: false)
-appstream_util = find_program('appstream-util', required: false)
+appstreamcli = find_program('appstreamcli', required: false)
 cargo = find_program('cargo', required: true)
 
 version = meson.project_version()


### PR DESCRIPTION
- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Mark the developer name as untranslatable
- Remove dubplicated Purism tag to pass validation test
- Use appstreamcli to validate appdata