### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/io.github.seadve.Mousai.desktop.in.in
+++ b/data/io.github.seadve.Mousai.desktop.in.in
@@ -9,4 +9,5 @@ Categories=GNOME;GTK;Utility;
 Keywords=Shazam;Audio;Music;Song;Recognize;Identify;Recognition;
 Icon=@icon@
 StartupNotify=true
+DBusActivatable=true
 X-Purism-FormFactor=Workstation;Mobile;

--- a/data/io.github.seadve.Mousai.service.in
+++ b/data/io.github.seadve.Mousai.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@app-id@
+Exec=@bindir@/mousai --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -74,3 +74,14 @@ if glib_compile_schemas.found()
     ],
   )
 endif
+
+# D-Bus service file
+service_conf = configuration_data()
+service_conf.set('app-id', application_id)
+service_conf.set('bindir', bindir)
+configure_file(
+  input: '@0@.service.in'.format(base_id),
+  output: '@0@.service'.format(application_id),
+  configuration: service_conf,
+  install_dir: datadir / 'dbus-1' / 'services'
+)


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html