### PR TITLE
chore: bump msrv to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.7.9"
 authors = ["Dave Patrick Caberto <davecruz48@gmail.com>"]
 license = "GPL-3.0-or-later"
 edition = "2024"
+rust-version = "1.88"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Mousai can't be built with rustc << 1.88 after 80cddf5de19e195a8c97d45052a5a233800e4ff1 so let's bump the minimum supported rust version.

Example error:

```rust
error[E0658]: `let` expressions in this position are unstable
  --> src/application.rs:67:16
   |
67 |             if let Some((env, _, _)) = self.env.get()
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
```